### PR TITLE
zsh modifications

### DIFF
--- a/.github/scripts/build/cli
+++ b/.github/scripts/build/cli
@@ -66,7 +66,7 @@ done
 
 # zsh
 cd "$CONFIGDIR"
-zip -qr $RESULTS/bin/zsh.com share/zsh
+zip -qr $RESULTS/bin/zsh.com share/zsh zshenv
 cd "$BASELOC"
 
 

--- a/.github/scripts/setup
+++ b/.github/scripts/setup
@@ -8,6 +8,8 @@ sudo apt-get install -y ca-certificates libssl-dev
 sudo apt-get install -y qemu qemu-utils qemu-user-static
 sudo apt-get install -y texinfo
 sudo apt-get install -y cmake ninja-build
+sudo apt-get install -y bison
+sudo apt-get install -y zip
 
 # the zip folder
 sudo mkdir -p /zip

--- a/cli/zsh-5.9/superconfigure
+++ b/cli/zsh-5.9/superconfigure
@@ -34,11 +34,23 @@ fi
 cd zsh*/
 # cp $COSMOS/common.cache ./config.cache
 ./configure --cache-file=config.cache --prefix="$COSMOS" --disable-dynamic \
-    --datarootdir=/zip/share --with-tcsetpgrp \
+    --enable-zshenv=/zip/zshenv --datarootdir=/zip/share --with-tcsetpgrp \
     CFLAGS="-Os -I$COSMOS/include/ncurses"
+
+link_static() {
+  for module_name in "$@"; do
+    grep -n "name=zsh/$module_name " config.modules | cut -d: -f1 | \
+      while read line; do
+        sed -i "${line}s/link=no/link=static/" config.modules
+      done
+  done
+}
+
+link_static mathfunc regex
 
 # run make and/or make install
 make V=0 -s -j$MAXPROC
 make install V=0 -s -j$MAXPROC
+echo 'source /etc/zshenv' > /zip/zshenv
 
 echo "DONE."


### PR DESCRIPTION
Configures zsh.com to read zshenv out of /zip/zshenv. The binary ships
with a zshenv that simply contains `source /etc/zshenv`, preserving the
default behavior with an extra layer of indirection. This lets users
customize their zsh.com to behave any way they desire without having to
recompile.

Also links in a couple commonly used modules: regex support and
mathfuncs. More could be linked in as well, these just seemed like the
essentials.