### PR TITLE
Ship all zsh rc files, plus zshinit shim

### DIFF
--- a/.github/scripts/build/cli
+++ b/.github/scripts/build/cli
@@ -42,7 +42,7 @@ mkdir -p "$RESULTS"
 cd "$CONFIGDIR"
 mkdir -p etc usr/share
 cp -r /zip/usr/share/terminfo ./usr/share
-cp -r /zip/usr/share/zsh ./usr/share || true
+cp -r /zip/usr/share/zsh ./usr/share
 cp /zip/etc/z* ./etc
 ls -al /zip
 

--- a/.github/scripts/build/cli
+++ b/.github/scripts/build/cli
@@ -40,10 +40,10 @@ mkdir -p "$RESULTS"
 
 # the zip folder
 cd "$CONFIGDIR"
-mkdir -p usr/share
+mkdir -p etc usr/share
 cp -r /zip/usr/share/terminfo ./usr/share
 cp -r /zip/usr/share/zsh ./usr/share || true
-cp /zip/zshenv ./
+cp /zip/etc/z* ./etc
 ls -al /zip
 
 
@@ -67,7 +67,8 @@ done
 
 # zsh
 cd "$CONFIGDIR"
-zip -qr $RESULTS/bin/zsh.com usr/share/zsh zshenv
+zip -qr $RESULTS/bin/zsh.com usr/share/zsh
+zip -qr0 $RESULTS/bin/zsh.com etc
 cd "$BASELOC"
 
 

--- a/.github/scripts/build/cosmos
+++ b/.github/scripts/build/cosmos
@@ -41,9 +41,10 @@ mkdir -p "$RESULTS"
 
 # cli
 cd "$CONFIGDIR"
-mkdir -p usr/share
+mkdir -p etc usr/share
 cp -r /zip/usr/share/terminfo ./usr/share
-cp -r /zip/usr/share/zsh ./usr/share || true
+cp -r /zip/usr/share/zsh ./usr/share
+cp /zip/etc/z* ./etc
 ls -al /zip
 
 cd $BASELOC
@@ -67,6 +68,7 @@ done
 # zsh
 cd "$CONFIGDIR"
 zip -qr $RESULTS/bin/zsh.com usr/share/zsh
+zip -qr0 $RESULTS/bin/zsh.com etc
 cd "$BASELOC"
 
 

--- a/cli/zsh-5.9/superconfigure
+++ b/cli/zsh-5.9/superconfigure
@@ -35,12 +35,18 @@ cd zsh*/
 cp ../saved_config.cache ./config.cache
 ./configure --cache-file=config.cache --prefix="$COSMOS" --disable-dynamic \
     --datarootdir=/zip/usr/share --with-tcsetpgrp --enable-gdbm \
-    --enable-zshenv=/zip/zshenv  \
+    --enable-zshenv=/zip/etc/zshenv  --enable-zshrc=/zip/etc/zshrc \
+    --enable-zprofile=/zip/etc/zprofile --enable-zlogin=/zip/etc/zlogin \
+    --enable-zlogout=/zip/etc/zlogout \
     CFLAGS="-Os -I$COSMOS/include/ncurses -I$COSMOS/include/gdbm"
 
 # run make and/or make install
 make V=0 -s -j$MAXPROC
 make install V=0 -s -j$MAXPROC
-cp ../zshenv /zip/zshenv
+mkdir -p /zip/etc
+cp ../zshinit /zip/etc
+for rcfile in z{sh{env,rc},profile,log{in,out}}; do
+  echo ". /zip/etc/zshinit $rcfile" > /zip/etc/$rcfile
+done
 
 echo "DONE."

--- a/cli/zsh-5.9/zshenv
+++ b/cli/zsh-5.9/zshenv
@@ -1,3 +1,0 @@
-if [ -f /etc/zshenv ]; then
-    source /etc/zshenv
-fi

--- a/cli/zsh-5.9/zshinit
+++ b/cli/zsh-5.9/zshinit
@@ -1,0 +1,9 @@
+[[ -z ${(t)rcpath} || ${(t)rcpath} != array ]] &&
+  rcpath=(/etc{,/zsh})
+for d in $rcpath; do
+  local rcfile="$d/$1"
+  [[ -f "$rcfile" ]] && {
+    . "$rcfile"
+    return $?
+  }
+done


### PR DESCRIPTION
zshenv alone is insufficient to fully customize zsh's rc file loading process without intrusive source changes. As such, we configure zsh to load all of its rc files out of the zip. Each rc file in the zip is a simple shim that effectively calls `. /zip/etc/zshinit $0` (but they can't actually use `$0` since zsh does not set this when sourcing rc files.)

zshinit is a custom rc file loader with a search path configurable as `rcpath`, analogous to `path` and `fpath`. The default rcpath is:

    /etc{,/zsh}

This searches for rc files in the default location as well as the one configured by Debian. Note that since rcpath is customizable, it can be modified in `/etc{,/zsh}/zshenv` (as well as `/zip/etc/zshenv`.)

This change also stores the `/zip/etc` files uncompressed in the hopes that that shaves a few ticks off of startup time.