### PR TITLE
zshinit returns 0 if it doesn't find a file

### DIFF
--- a/cli/zsh-5.9/zshinit
+++ b/cli/zsh-5.9/zshinit
@@ -7,3 +7,4 @@ for d in $rcpath; do
     return $?
   }
 done
+return 0


### PR DESCRIPTION
Fixes a minor regression — if the last rc file zsh.com tried to load did not exist, your shell would initially have a `$?` of 1 instead of 0.