### PR TITLE
Add gui package category with SDL2

### DIFF
--- a/.github/scripts/build/gui
+++ b/.github/scripts/build/gui
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -eux
+
+make ARCH=x86_64 gui
+make ARCH=aarch64 gui
+# rm -f cosmo.setup.*
+
+export MODE=
+export MODE_AARCH64=aarch64
+export BASELOC=$(realpath $PWD)
+export COSMO=$BASELOC/cosmopolitan
+export COSMOS_X86=$BASELOC/cosmos/x86_64
+export COSMOS_AARCH64=$BASELOC/cosmos/aarch64
+export RESULTS=$BASELOC/results
+
+APELINK=$COSMO/o//tool/build/apelink.com
+APELINKFLAGS=
+
+apelinkpls () {
+    OUTPUT="$1"
+    OUTPUT_X86_64="$2"
+    OUTPUT_AARCH64="$3"
+    OLDNAME_X86_64="$(basename -- $OUTPUT_X86_64)"
+    OLDNAME_AARCH64="$(basename -- $OUTPUT_AARCH64)"
+    TARG_FOLD="$(dirname $OUTPUT)"
+    "$APELINK" -l "$COSMO/o/$MODE/ape/ape.elf" \
+        -l "$COSMO/o/$MODE_AARCH64/ape/ape.elf" \
+        -M "$COSMO/ape/ape-m1.c" \
+        -o "$OUTPUT" \
+        "$OUTPUT_X86_64" \
+        "$OUTPUT_AARCH64"
+    cp "$OUTPUT_X86_64" "$TARG_FOLD/$OLDNAME_X86_64.x86_64"
+    cp "$OUTPUT_AARCH64" "$TARG_FOLD/$OLDNAME_AARCH64.aarch64"
+}
+
+echo "creating fat APEs"
+mkdir -p "$RESULTS"
+
+cd $BASELOC
+ls -al ./
+
+TESTLIST='
+checkkeys
+testgeometry
+testdraw2
+testscale
+testrendercopyex
+testsprite2
+testbounds
+testmessage
+'
+
+for EXE in $TESTLIST; do
+    apelinkpls $RESULTS/bin/$EXE.com $COSMOS_X86/libexec/installed-tests/SDL2/$EXE $COSMOS_AARCH64/libexec/installed-tests/SDL2/$EXE
+done
+
+cp $COSMOS_X86/libexec/installed-tests/SDL2/{sample,icon}.bmp $RESULTS/bin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        result: [compress, llvm, web, aarch64-gcc, x86_64-gcc, cli, datasette, pypack1, editor]
+        result: [compress, llvm, web, aarch64-gcc, x86_64-gcc, cli, datasette, pypack1, editor, gui]
     name: ${{ matrix.result }}
     steps:
       - name: Checkout the repository

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,18 @@ gcc: compiler/$(TARGET_ARCH)-gcc.built.$(ARCH)
 compiler/llvm-15.0.7.built.$(ARCH): compress/zlib-1.3.built.$(ARCH)
 llvm: compiler/llvm-15.0.7.built.$(ARCH)
 
+# gui
+
+gui/xorgproto-2023.2.built.$(ARCH): gui/util-macros-1.20.0.built.$(ARCH)
+gui/xcb-proto-1.16.0.built.$(ARCH): gui/util-macros-1.20.0.built.$(ARCH)
+gui/xtrans-1.5.0.built.$(ARCH): gui/xorgproto-2023.2.built.$(ARCH)
+gui/libXau-1.0.11.built.$(ARCH): gui/xorgproto-2023.2.built.$(ARCH) gui/xtrans-1.5.0.built.$(ARCH)
+gui/libxcb-1.16.built.$(ARCH): gui/libXau-1.0.11.built.$(ARCH) gui/xcb-proto-1.16.0.built.$(ARCH)
+gui/libX11-1.8.7.built.$(ARCH): gui/libxcb-1.16.built.$(ARCH)
+gui/libXext-1.3.5.built.$(ARCH): gui/libX11-1.8.7.built.$(ARCH)
+gui/SDL2-2.28.5.built.$(ARCH): gui/libXext-1.3.5.built.$(ARCH) gui/libX11-1.8.7.built.$(ARCH)
+gui: gui/SDL2-2.28.5.built.$(ARCH)
+
 ######
 
 cosmos: python cli editor compress

--- a/gui/SDL2-2.28.5/minimal.diff
+++ b/gui/SDL2-2.28.5/minimal.diff
@@ -1,0 +1,22 @@
+diff -r --unified SDL2-2.28.5-old/configure.ac SDL2-2.28.5/configure.ac
+--- SDL2-2.28.5-old/configure.ac	2023-11-02 18:03:38.000000000 +0100
++++ SDL2-2.28.5/configure.ac	2023-12-02 21:51:13.884690520 +0100
+@@ -1906,6 +1906,7 @@
+                 fi
+                 ;;
+         esac
++        LIBS="$LIBS -lxcb -lXau"
+         AC_PATH_X
+         AC_PATH_XTRA
+         if test x$have_x = xyes; then
+diff -r --unified SDL2-2.28.5-old/src/thread/pthread/SDL_systhread.c SDL2-2.28.5/src/thread/pthread/SDL_systhread.c
+--- SDL2-2.28.5-old/src/thread/pthread/SDL_systhread.c	2023-11-02 18:03:38.000000000 +0100
++++ SDL2-2.28.5/src/thread/pthread/SDL_systhread.c	2023-12-02 21:49:06.324710657 +0100
+@@ -18,6 +18,7 @@
+      misrepresented as being the original software.
+   3. This notice may not be removed or altered from any source distribution.
+ */
++#include <libc/sysv/consts/sched.h>
+ #include "../../SDL_internal.h"
+ 
+ #include "SDL_system.h"

--- a/gui/SDL2-2.28.5/superconfigure
+++ b/gui/SDL2-2.28.5/superconfigure
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -e
+shopt -s expand_aliases
+
+# check for cosmo dirs
+if [ -z ${COSMO+x} ]; then 
+    echo "could not find COSMO source directory!";
+    exit 1
+fi
+
+if [ -z ${COSMOS+x} ]; then 
+    echo "could not find COSMOS install directory!";
+    exit 1
+fi
+
+alias strip=$STRIP
+alias ar=$AR
+
+if [[ -f sources.tar.gz ]]; then
+    # we already downloaded it
+    cd SDL2*
+    make V=0 -s -i clean || true
+    cd test
+    make V=0 -s -i clean || true
+    cd ../..
+else
+    # download the source code
+    wget -q https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-2.28.5.tar.gz -O sources.tar.gz
+    tar -xzf sources.tar.gz
+
+    # apply patches if any
+    patch -p0 -i minimal.diff
+fi
+
+# go into the source folder, configure
+cd SDL2*
+aclocal --force
+autoconf --force
+./configure \
+    --disable-shared --enable-static\
+    --without-pic --prefix=$COSMOS\
+    --disable-{pulseaudio,diskaudio,sndio}\
+    --disable-video-{kmsdrm,vulkan,opengles2}\
+    --with-x --enable-video-x11\
+    CFLAGS="-Os"
+
+# run make and/or make install
+make V=0 -s -j$MAXPROC
+make install V=0 -s -j$MAXPROC
+
+cd test
+./configure \
+    --disable-shared --enable-static\
+    --without-pic --prefix=$COSMOS\
+    CFLAGS="-Os" SDL_LIBS="$(pkg-config --libs sdl2) -lxcb -lXau"
+
+make V=0 -j$MAXPROC
+make install V=0 -j$MAXPROC
+
+echo "DONE."
+

--- a/gui/libX11-1.8.7/minimal.diff
+++ b/gui/libX11-1.8.7/minimal.diff
@@ -1,0 +1,10 @@
+--- libX11-1.8.7-old/src/XlibInt.c	2023-10-03 18:37:42.000000000 +0200
++++ libX11-1.8.7/src/XlibInt.c	2023-12-02 21:38:43.244810320 +0100
+@@ -31,6 +31,7 @@
+  *	interface library (Xlib) to the X Window System Protocol V11.0.
+  */
+ 
++#include <poll.h>
+ #ifdef WIN32
+ #define _XLIBINT_
+ #endif

--- a/gui/libX11-1.8.7/superconfigure
+++ b/gui/libX11-1.8.7/superconfigure
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+shopt -s expand_aliases
+
+# check for cosmo dirs
+if [ -z ${COSMO+x} ]; then 
+    echo "could not find COSMO source directory!";
+    exit 1
+fi
+
+if [ -z ${COSMOS+x} ]; then 
+    echo "could not find COSMOS install directory!";
+    exit 1
+fi
+
+alias strip=$STRIP
+alias ar=$AR
+
+if [[ -f sources.tar.gz ]]; then
+    # we already downloaded it
+    cd libX11*
+    make V=0 -s -i clean || true
+    cd ..
+else
+    # download the source code
+    wget -q https://www.x.org/archive/individual/lib/libX11-1.8.7.tar.gz -O sources.tar.gz
+    tar -xzf sources.tar.gz
+
+    # apply patches if any
+    patch -p0 -i minimal.diff
+fi
+
+# go into the source folder, configure
+cd libX11*
+cp $COSMOS/common.cache ./config.cache
+./configure --cache-file=config.cache\
+    --disable-shared --enable-static\
+    --without-pic --prefix=$COSMOS\
+    --without-xmlto\
+    CFLAGS="-Os"
+
+# run make and/or make install
+make V=0 -s -j$MAXPROC
+make install V=0 -s -j$MAXPROC
+
+echo "DONE."

--- a/gui/libXau-1.0.11/superconfigure
+++ b/gui/libXau-1.0.11/superconfigure
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+shopt -s expand_aliases
+
+# check for cosmo dirs
+if [ -z ${COSMO+x} ]; then 
+    echo "could not find COSMO source directory!";
+    exit 1
+fi
+
+if [ -z ${COSMOS+x} ]; then 
+    echo "could not find COSMOS install directory!";
+    exit 1
+fi
+
+alias strip=$STRIP
+alias ar=$AR
+
+if [[ -f sources.tar.gz ]]; then
+    # we already downloaded it
+    cd libXau*
+    make V=0 -s -i clean || true
+    cd ..
+else
+    # download the source code
+    wget -q https://www.x.org/archive/individual/lib/libXau-1.0.11.tar.gz -O sources.tar.gz
+    tar -xzf sources.tar.gz
+
+    # apply patches if any
+    # patch -p0 -i minimal.diff
+fi
+
+# go into the source folder, configure
+cd libXau*
+cp $COSMOS/common.cache ./config.cache
+./configure --cache-file=config.cache\
+    --disable-shared --enable-static\
+    --without-pic --prefix=$COSMOS\
+    CFLAGS="-Os"
+
+# run make and/or make install
+make V=0 -s -j$MAXPROC
+make install V=0 -s -j$MAXPROC
+
+echo "DONE."

--- a/gui/libXext-1.3.5/superconfigure
+++ b/gui/libXext-1.3.5/superconfigure
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+shopt -s expand_aliases
+
+# check for cosmo dirs
+if [ -z ${COSMO+x} ]; then 
+    echo "could not find COSMO source directory!";
+    exit 1
+fi
+
+if [ -z ${COSMOS+x} ]; then 
+    echo "could not find COSMOS install directory!";
+    exit 1
+fi
+
+alias strip=$STRIP
+alias ar=$AR
+
+if [[ -f sources.tar.gz ]]; then
+    # we already downloaded it
+    cd libXext*
+    make V=0 -s -i clean || true
+    cd ..
+else
+    # download the source code
+    wget -q https://www.x.org/archive/individual/lib/libXext-1.3.5.tar.gz -O sources.tar.gz
+    tar -xzf sources.tar.gz
+
+    # apply patches if any
+    # patch -p0 -i minimal.diff
+fi
+
+# go into the source folder, configure
+cd libXext*
+cp $COSMOS/common.cache ./config.cache
+./configure --cache-file=config.cache\
+    --disable-shared --enable-static\
+    --without-pic --prefix=$COSMOS\
+    CFLAGS="-Os"
+
+# run make and/or make install
+make V=0 -s -j$MAXPROC
+make install V=0 -s -j$MAXPROC
+
+echo "DONE."

--- a/gui/libxcb-1.16/minimal.diff
+++ b/gui/libxcb-1.16/minimal.diff
@@ -1,0 +1,11 @@
+--- libxcb-1.16-old/src/config.h.in	2023-08-16 22:18:36.000000000 +0200
++++ libxcb-1.16/src/config.h.in	2023-12-02 22:47:57.624157502 +0100
+@@ -28,7 +28,7 @@
+ #undef HAVE_MINIX_CONFIG_H
+ 
+ /* Define if your platform supports sendmsg */
+-#undef HAVE_SENDMSG
++#undef HAVE_SENDMSG_BLOCK
+ 
+ /* Have the sockaddr_un.sun_len member. */
+ #undef HAVE_SOCKADDR_SUN_LEN

--- a/gui/libxcb-1.16/superconfigure
+++ b/gui/libxcb-1.16/superconfigure
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+shopt -s expand_aliases
+
+# check for cosmo dirs
+if [ -z ${COSMO+x} ]; then 
+    echo "could not find COSMO source directory!";
+    exit 1
+fi
+
+if [ -z ${COSMOS+x} ]; then 
+    echo "could not find COSMOS install directory!";
+    exit 1
+fi
+
+alias strip=$STRIP
+alias ar=$AR
+
+if [[ -f sources.tar.gz ]]; then
+    # we already downloaded it
+    cd libxcb*
+    make V=0 -s -i clean || true
+    cd ..
+else
+    # download the source code
+    wget -q https://www.x.org/archive/individual/lib/libxcb-1.16.tar.gz -O sources.tar.gz
+    tar -xzf sources.tar.gz
+
+    # apply patches if any
+    patch -p0 -i minimal.diff
+fi
+
+# go into the source folder, configure
+cd libxcb*
+cp $COSMOS/common.cache ./config.cache
+./configure --cache-file=config.cache\
+    --disable-shared --enable-static\
+    --without-pic --prefix=$COSMOS\
+    CFLAGS="-Os"
+
+# run make and/or make install
+make V=0 -s -j$MAXPROC
+make install V=0 -s -j$MAXPROC
+
+echo "DONE."

--- a/gui/util-macros-1.20.0/superconfigure
+++ b/gui/util-macros-1.20.0/superconfigure
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -e
+shopt -s expand_aliases
+
+# check for cosmo dirs
+if [ -z ${COSMO+x} ]; then 
+    echo "could not find COSMO source directory!";
+    exit 1
+fi
+
+if [ -z ${COSMOS+x} ]; then 
+    echo "could not find COSMOS install directory!";
+    exit 1
+fi
+
+alias strip=$STRIP
+alias ar=$AR
+
+if [[ -f sources.tar.gz ]]; then
+    # we already downloaded it
+    cd util-macros*
+    make V=0 -s -i clean || true
+    cd ..
+else
+    # download the source code
+    wget -q https://www.x.org/archive/individual/util/util-macros-1.20.0.tar.gz -O sources.tar.gz
+    tar -xzf sources.tar.gz
+
+    # apply patches if any
+    # patch -p0 -i minimal.diff
+fi
+
+# go into the source folder, configure
+cd util-macros*
+cp $COSMOS/common.cache ./config.cache
+./configure --cache-file=config.cache\
+    --prefix=$COSMOS\
+    CFLAGS="-Os"
+
+# run make and/or make install
+make V=0 -s -j$MAXPROC
+make install V=0 -s -j$MAXPROC
+
+echo "DONE."

--- a/gui/xcb-proto-1.16.0/superconfigure
+++ b/gui/xcb-proto-1.16.0/superconfigure
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+shopt -s expand_aliases
+
+# check for cosmo dirs
+if [ -z ${COSMO+x} ]; then 
+    echo "could not find COSMO source directory!";
+    exit 1
+fi
+
+if [ -z ${COSMOS+x} ]; then 
+    echo "could not find COSMOS install directory!";
+    exit 1
+fi
+
+alias strip=$STRIP
+alias ar=$AR
+
+if [[ -f sources.tar.gz ]]; then
+    # we already downloaded it
+    cd xcb-proto*
+    make V=0 -s -i clean || true
+    cd ..
+else
+    # download the source code
+    wget -q https://www.x.org/archive/individual/proto/xcb-proto-1.16.0.tar.gz -O sources.tar.gz
+    tar -xzf sources.tar.gz
+
+    # apply patches if any
+    # patch -p0 -i minimal.diff
+fi
+
+# go into the source folder, configure
+cd xcb-proto*
+cp $COSMOS/common.cache ./config.cache
+./configure --cache-file=config.cache\
+    --disable-shared --enable-static\
+    --without-pic --prefix=$COSMOS\
+    CFLAGS="-Os"
+
+# run make and/or make install
+make V=0 -s -j$MAXPROC
+make install V=0 -s -j$MAXPROC
+
+echo "DONE."

--- a/gui/xorgproto-2023.2/superconfigure
+++ b/gui/xorgproto-2023.2/superconfigure
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+shopt -s expand_aliases
+
+# check for cosmo dirs
+if [ -z ${COSMO+x} ]; then 
+    echo "could not find COSMO source directory!";
+    exit 1
+fi
+
+if [ -z ${COSMOS+x} ]; then 
+    echo "could not find COSMOS install directory!";
+    exit 1
+fi
+
+alias strip=$STRIP
+alias ar=$AR
+
+if [[ -f sources.tar.gz ]]; then
+    # we already downloaded it
+    cd xorgproto*
+    make V=0 -s -i clean || true
+    cd ..
+else
+    # download the source code
+    wget -q https://www.x.org/archive/individual/proto/xorgproto-2023.2.tar.gz -O sources.tar.gz
+    tar -xzf sources.tar.gz
+
+    # apply patches if any
+    # patch -p0 -i minimal.diff
+fi
+
+# go into the source folder, configure
+cd xorgproto*
+cp $COSMOS/common.cache ./config.cache
+./configure --cache-file=config.cache\
+    --disable-shared --enable-static\
+    --without-pic --prefix=$COSMOS\
+    CFLAGS="-Os"
+
+# run make and/or make install
+make V=0 -s -j$MAXPROC
+make install V=0 -s -j$MAXPROC
+
+echo "DONE."

--- a/gui/xtrans-1.5.0/superconfigure
+++ b/gui/xtrans-1.5.0/superconfigure
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -e
+shopt -s expand_aliases
+
+# check for cosmo dirs
+if [ -z ${COSMO+x} ]; then 
+    echo "could not find COSMO source directory!";
+    exit 1
+fi
+
+if [ -z ${COSMOS+x} ]; then 
+    echo "could not find COSMOS install directory!";
+    exit 1
+fi
+
+alias strip=$STRIP
+alias ar=$AR
+
+if [[ -f sources.tar.gz ]]; then
+    # we already downloaded it
+    cd xtrans*
+    make V=0 -s -i clean || true
+    cd ..
+else
+    # download the source code
+    wget -q https://www.x.org/archive/individual/lib/xtrans-1.5.0.tar.gz -O sources.tar.gz
+    tar -xzf sources.tar.gz
+
+    # apply patches if any
+    # patch -p0 -i minimal.diff
+fi
+
+# go into the source folder, configure
+cd xtrans*
+cp $COSMOS/common.cache ./config.cache
+./configure --cache-file=config.cache\
+    --disable-shared --enable-static\
+    --without-pic --prefix=$COSMOS\
+    CFLAGS="-Os"
+
+# run make and/or make install
+make V=0 -s -j$MAXPROC
+make install V=0 -s -j$MAXPROC
+
+echo "DONE."

--- a/vars/aarch64
+++ b/vars/aarch64
@@ -22,6 +22,7 @@ export COSMOS=$BASELOC/cosmos/$ARCH
 export RESULTS=$BASELOC/results
 export DIRCONFIG=$BASELOC/cosmos/config
 export PKG_CONFIG_PATH="$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config"
+export ACLOCAL_PATH="$COSMOS/share/aclocal"
 
 PREFIX="$COSMO/cosmocc/bin/$ARCH-unknown-cosmo"
 export CC=$PREFIX-cc

--- a/vars/x86_64
+++ b/vars/x86_64
@@ -22,6 +22,7 @@ export COSMOS=$BASELOC/cosmos/$ARCH
 export RESULTS=$BASELOC/results
 export DIRCONFIG=$BASELOC/cosmos/config
 export PKG_CONFIG_PATH="$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config"
+export ACLOCAL_PATH="$COSMOS/share/aclocal"
 
 PREFIX="$COSMO/cosmocc/bin/$ARCH-unknown-cosmo"
 export CC=$PREFIX-cc


### PR DESCRIPTION
This PR adds `gui.zip`, a package category that currently only outputs SDL2 tests in results. It is currently only a preliminary demo - there is no audio support at all and the only video driver is X11. Because of the latter, vcXsrv is required on Windows and XQuartz is required on macOS.
Results were tested on Windows x86_64, Linux x86_64, Linux aarch64, macOS aarch64.