### PR TITLE
gcc: Enable SJLJ exceptions

### DIFF
--- a/compiler/gcc-11.2-patched/config-wrapper
+++ b/compiler/gcc-11.2-patched/config-wrapper
@@ -19,6 +19,7 @@ $SRC_DIR/configure --prefix=$COSMOS\
     --disable-libmpx --enable-initfini-array --disable-libstdcxx --without-libffi \
     --without-libatomic --disable-gcov --disable-analyzer --disable-libvtv \
     --disable-libgomp --disable-libatomic \
+    --enable-sjlj-exceptions \
     --with-gnu-as=yes --with-gnu-ld=yes --build=$ARCH-linux-gnu \
     --target=$FULL_TARGET \
-    CFLAGS="-Os -D_LARGEFILE64_SOURCE=1"
+    CFLAGS="-Os -D_LARGEFILE64_SOURCE=1 -DDONT_USE_BUILTIN_SETJMP=1"


### PR DESCRIPTION
This would enable unwind functionality for cosmo programs without having to embed additional information in the binaries.

Thanks to @codehz for the suggestion.