### PR TITLE
Improve Clarity and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,29 @@ and others. For each of these, the source code is downloaded from the upstream
 sources, compiled for `x86_64` and `aarch64`, and finally combined into a fat
 binary using Cosmopolitan Libc's `apelink` program.
 
+# What's included in the build
+The built software is split into the following zip files:  
+**compress.zip**  
+contains `tar`, `zip`, `unzip`, `bzip2`, `zstd`, `xz`, `brotli`, `gzip`, and `pigz`.  
+**cli.zip**  
+contains `bash`, `zsh`, `grep`, `less`, `lua`, `find`, `GNU coreutils`, and `ninja`.  
+**editor.zip**  
+contains `vim`, `nano`, and `emacs`.  
+**x86_64-gcc.zip**  
+contains the `gcc-13` and `binutils-2.39` tools targeting 32-bit (x86-64-linux-cosmo).  
+**aarch64-gcc.zip**  
+contains the `gcc-13` and `binutils-2.39` tools targeting 64-bit (aarch64-linux-cosmo).  
+**datasette.zip**  
+contains `datasette` a build of CPython 3.11 with the datasette library.  
+**pypack1.zip**  
+contains `python`, a build of CPython 3.11 with a bunch of cli libraries like `black`, `cookiecutter`.  
+**web.zip**  
+contains `links`, `wget`, `curl`, `git`, and `rsync`.  
+**gui.zip**  
+contains SDL2 test binaries built with `libX11` (experimental, requires X Server to be running on the host system).  
+**lang.zip**  
+contains languages [`berry`](https://berry-lang.github.io/), [`janet`](https://janet-lang.org/), [`lua`](https://www.lua.org/), [`php`](https://www.php.net/).  
+
 # Where can I download the built software?
 
 The  [`Releases` page](https://github.com/ahgamut/superconfigure/releases)
@@ -15,6 +38,9 @@ Actions.
 
 If you'd like to add your own software build scripts, submit a PR! Read up
 `config/README.md` how all of this works.
+
+> [!TIP]
+> If you're on Windows, after downloading the zip files you should rename the executables inside to end with `.exe` in order to run them.
 
 # How can I build these locally?
 


### PR DESCRIPTION
Hi,

When I went to the releases page, I was quite confused because there's no description of the files included on the entire first page. I had to search around and read older release notes to understand. I think it makes more sense to just have a description of what's included in the build in the `README.md` itself. 

This improves clarity.

I took care to include `lang.zip` which is in the latest release.

Also added a tip which is necessary to running these actually portable executables on Windows.