### PR TITLE
Adding .tgz support

### DIFF
--- a/config/default_dl.sh
+++ b/config/default_dl.sh
@@ -10,7 +10,7 @@ if [ "$URL" = "ERROR" ]; then
 fi
 
 case "$URL" in
-    *.tar.gz* )
+    *.tar.gz* | *.tgz* )
         wget -qO sources.tar.gz "$URL"
         ;;
     *.tar.xz* )


### PR DESCRIPTION
This PR adds support for the `.tgz` format. 
Additionally, I’d like to ask: why are there asterisks (*) at the end of patterns like `*.tar.gz*`?