### PR TITLE
Fixes on pkg-config leakage

### DIFF
--- a/.github/scripts/setup
+++ b/.github/scripts/setup
@@ -5,9 +5,9 @@ sudo apt update
 
 # ssl certs
 sudo apt-get install -y ca-certificates libssl-dev\
-    qemu-user qemu-system-x86 qemu-system-arm qemu-utils qemu-user-static\
+    qemu-user-static\
     texinfo groff libtool\
-    cmake ninja-build bison zip\
+    cmake ninja-build bison flex zip\
     pkg-config build-essential autoconf re2c
 
 # github workspace can be the build folder,

--- a/config/vars-aarch64
+++ b/config/vars-aarch64
@@ -7,8 +7,8 @@ export BASELOC=$(realpath "$PWD")
 export COSMO=$BASELOC/cosmopolitan
 export COSMOS=$BASELOC/cosmos/$ARCH
 export RESULTS=$BASELOC/results
-export PKG_CONFIG_PATH="$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config"
-export PKG_CONFIG_PATH_CUSTOM="$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config"
+#export PKG_CONFIG_PATH="$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config"
+export PKG_CONFIG_LIBDIR="$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config"
 export ACLOCAL_PATH="$COSMOS/share/aclocal"
 
 PREFIX="$COSMO/cosmocc/bin/$ARCH-unknown-cosmo"

--- a/config/vars-x86_64
+++ b/config/vars-x86_64
@@ -7,8 +7,8 @@ export BASELOC=$(realpath "$PWD")
 export COSMO=$BASELOC/cosmopolitan
 export COSMOS=$BASELOC/cosmos/$ARCH
 export RESULTS=$BASELOC/results
-export PKG_CONFIG_PATH=$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config
-export PKG_CONFIG_PATH_CUSTOM="$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config"
+#export PKG_CONFIG_PATH=$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config
+export PKG_CONFIG_LIBDIR=$COSMOS/lib/pkgconfig:$COSMOS/share/pkgconfig:$COSMOS/share/pkg-config
 export ACLOCAL_PATH="$COSMOS/share/aclocal"
 
 PREFIX="$COSMO/cosmocc/bin/$ARCH-unknown-cosmo"

--- a/editor/nano/config-wrapper
+++ b/editor/nano/config-wrapper
@@ -8,12 +8,11 @@ alias ar="$AR"
 
 export NCURSES_CONFIG="$COSMOS/bin/ncurses6-config"
 export NCURSESW_CONFIG="$COSMOS/bin/ncurses6-config"
-export NCURSES_CFLAGS="-I$COSMOS/include -I$COSMOS/include/ncurses"
+export NCURSESW_CFLAGS="-I$COSMOS/include/ncurses"
+export NCURSESW_LIBS="-L$COSMOS/lib -lncurses -ltinfo"
 
 "$BASELOC"/o/editor/nano/nano*/configure --sysconfdir="$COSMOS/share" --datarootdir="$COSMOS/share"\
     --prefix="$COSMOS"\
     --disable-nls --disable-rpath --disable-silent-rules\
-    CFLAGS="-Os -I$COSMOS/include -I$COSMOS/include/ncurses"\
-    LDFLAGS="-L$COSMOS/lib"\
-    NCURSES_LIBS="-L$COSMOS/lib -lncurses -ltinfo"\
-    NCURSESW_LIBS="-L$COSMOS/lib -lncurses -ltinfo"
+    CFLAGS="-Os -I$COSMOS/include"\
+    LDFLAGS="-L$COSMOS/lib"

--- a/gui/SDL2/config-wrapper
+++ b/gui/SDL2/config-wrapper
@@ -6,10 +6,12 @@ set -e
     --without-pic --prefix="$COSMOS"\
     --disable-pulseaudio\
     --disable-sndio\
+    --disable-nas\
     --disable-video-kmsdrm\
     --disable-video-vulkan\
     --disable-video-opengles2\
     --with-x --enable-video-x11\
+    --x-includes="$COSMOS/include" --x-libraries="$COSMOS/lib" \
     CFLAGS="-Os" SDL_STATIC_LIBS="-lXext -lX11 -lxcb -lXau"
 
 make V=0 -s -j"$MAXPROC"

--- a/gui/SDL2/minimal.diff
+++ b/gui/SDL2/minimal.diff
@@ -1,6 +1,15 @@
 diff -r --unified SDL2-2.28.5-old/configure.ac SDL2-2.28.5/configure.ac
 --- SDL2-2.28.5-old/configure.ac	2023-11-02 18:03:38.000000000 +0100
 +++ SDL2-2.28.5/configure.ac	2023-12-02 21:51:13.884690520 +0100
+@@ -349,7 +349,7 @@
+         AC_DEFINE(HAVE_MPROTECT, 1, [ ])
+         ],[]),
+     )
+-    AC_CHECK_FUNCS(malloc calloc realloc free getenv setenv putenv unsetenv bsearch qsort abs bcopy memset memcmp memcpy memmove wcslen wcslcpy wcslcat _wcsdup wcsdup wcsstr wcscmp wcsncmp wcscasecmp _wcsicmp wcsncasecmp _wcsnicmp strlen strlcpy strlcat _strrev _strupr _strlwr index rindex strchr strrchr strstr strtok_r itoa _ltoa _uitoa _ultoa strtod strtol strtoul _i64toa _ui64toa strtoll strtoull atoi atof strcmp strncmp _stricmp strcasecmp _strnicmp strncasecmp strcasestr vsscanf vsnprintf fopen64 fseeko fseeko64 sigaction setjmp nanosleep sysconf sysctlbyname getauxval elf_aux_info poll _Exit)
++    AC_CHECK_FUNCS(malloc calloc realloc free getenv setenv putenv unsetenv bsearch qsort abs bcopy memset memcmp memcpy memmove wcslen wcslcpy wcslcat _wcsdup wcsdup wcsstr wcscmp wcsncmp wcscasecmp _wcsicmp wcsncasecmp _wcsnicmp strlen strlcpy strlcat _strrev _strupr _strlwr index rindex strchr strrchr strstr strtok_r itoa _ltoa _uitoa _ultoa strtod strtol strtoul _i64toa _ui64toa strtoll strtoull atoi atof strcmp strncmp _stricmp strcasecmp _strnicmp strncasecmp strcasestr vsscanf vsnprintf fopen64 fseeko fseeko64 sigaction setjmp nanosleep sysconf getauxval elf_aux_info poll _Exit)
+ 
+     AC_CHECK_LIB(m, pow, [LIBS="$LIBS -lm"; EXTRA_LDFLAGS="$EXTRA_LDFLAGS -lm"])
+     AC_CHECK_FUNCS(acos acosf asin asinf atan atanf atan2 atan2f ceil ceilf copysign copysignf cos cosf exp expf fabs fabsf floor floorf trunc truncf fmod fmodf log logf log10 log10f lround lroundf pow powf round roundf scalbn scalbnf sin sinf sqrt sqrtf tan tanf)
 @@ -1906,6 +1906,7 @@
                  fi
                  ;;

--- a/lib/libpng/BUILD.mk
+++ b/lib/libpng/BUILD.mk
@@ -5,6 +5,7 @@ LIBPNG_CONFIG_ARGS = --prefix=$$(COSMOS)\
 	--disable-arm-neon\
     --without-pic --with-gnu-ld\
     --disable-rpath\
+    --with-zlib-prefix=_Cz_\
     CFLAGS="-Os"
 
 $(eval $(call DOWNLOAD_SOURCE,lib/libpng,$(LIBPNG_SRC)))

--- a/lib/readline/minimal.diff
+++ b/lib/readline/minimal.diff
@@ -18,3 +18,13 @@ diff -r --unified readline-8.2a/input.c readline-8.2/input.c
    return 0;
  }
  
+--- readline-8.2a/readline.pc.in	2019-04-09 02:22:47.000000000 +0800
++++ readline-8.2/readline.pc.in	2019-04-09 02:22:47.000000000 +0800
+@@ -7,6 +7,5 @@
+ Description: Gnu Readline library for command line editing
+ URL: http://tiswww.cwru.edu/php/chet/readline/rltop.html
+ Version: @LIBVERSION@
+-Requires.private: @TERMCAP_PKG_CONFIG_LIB@
+-Libs: -L${libdir} -lreadline
++Libs: -L${libdir} -lreadline -l@TERMCAP_PKG_CONFIG_LIB@
+ Cflags: -I${includedir}


### PR DESCRIPTION
Scripts in `config/vars-*` specifics `PKG_CONFIG_PATH` and `PKG_CONFIG_PATH_CUSTOM`(which I can't understand), this actually **adds** paths to `pkg-config`, leads to some wrong packages detected in the base system, when it has something installed and those in superconfigure don't configured to include.
Try replace with `PKG_CONFIG_LIBDIR`. Seems fine.

Another small fix: force SDL2's X path.