### PR TITLE
file: disable broken magic file detection

### DIFF
--- a/cli/file/minimal.diff
+++ b/cli/file/minimal.diff
@@ -1,7 +1,5 @@
-diff --git a/magic/Makefile.am b/magic/Makefile.am
-index e0f9034..421fcbb 100644
---- a/magic/Makefile.am
-+++ b/magic/Makefile.am
+--- file-FILE5_46/magic/Makefile.am
++++ file-FILE5_46/magic/Makefile.am
 @@ -31,7 +31,6 @@ $(MAGIC_FRAGMENT_DIR)/apt \
  $(MAGIC_FRAGMENT_DIR)/archive \
  $(MAGIC_FRAGMENT_DIR)/aria \


### PR DESCRIPTION
Discovered that file 5.46 doesn't like building this specific magic file entry when built with cosmo. 